### PR TITLE
Use centralized WebSocket hook for payload-aware updates

### DIFF
--- a/frontend/src/features/admin/pages/ModernRequestManagementPage.tsx
+++ b/frontend/src/features/admin/pages/ModernRequestManagementPage.tsx
@@ -49,11 +49,7 @@ export const ModernRequestManagementPage: React.FC = () => {
   
   const { lastMessage } = useWebSocket();
 
-  useEffect(() => {
-    fetchRequests();
-  }, [pagination.current, pagination.pageSize, statusFilter, lastMessage]);
-
-  const fetchRequests = async () => {
+  const fetchRequests = useCallback(async () => {
     setLoading(true);
     try {
       const params = {
@@ -69,7 +65,21 @@ export const ModernRequestManagementPage: React.FC = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [pagination.current, pagination.pageSize, statusFilter, t]);
+
+  useEffect(() => {
+    fetchRequests();
+  }, [fetchRequests]);
+
+  useEffect(() => {
+    if (!lastMessage?.payload) {
+      return;
+    }
+
+    if (['request_created', 'request_updated', 'request_deleted', 'status_update'].includes(lastMessage.type)) {
+      fetchRequests();
+    }
+  }, [lastMessage, fetchRequests]);
 
   const handleDelete = async (ids: number[]) => {
     Modal.confirm({

--- a/frontend/src/features/user/UserApp.tsx
+++ b/frontend/src/features/user/UserApp.tsx
@@ -20,7 +20,11 @@ export const UserApp: React.FC = () => {
   const { isConnected, lastMessage } = useWebSocket();
 
   useEffect(() => {
-    if (lastMessage) {
+    if (!lastMessage?.payload) {
+      return;
+    }
+
+    if (['request_created', 'request_updated', 'request_deleted', 'status_update'].includes(lastMessage.type)) {
       refetch();
     }
   }, [lastMessage, refetch]);


### PR DESCRIPTION
## Summary
- switch the legacy `useWebSocket` hook over to the centralized manager so connections include the client identifier and emit structured payloads
- gate admin and user request refresh logic on WebSocket events that carry payloads so real-time updates are only triggered by meaningful messages

## Testing
- npm run lint *(fails: existing lint errors across the codebase unrelated to the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68cfe06e7b7c83248b19ed2e2a7b3b8d